### PR TITLE
Make sure isExcluded() never returns None

### DIFF
--- a/default.py
+++ b/default.py
@@ -87,7 +87,7 @@ def isExcluded(movieFullPath):
             Debug("isExcluded(): Video is playing from '%s', which is currently set as excluded path 5." % ExcludePath5)
             return False
 
-	return True
+    return True
 
 
 class AutoSubsPlayer(xbmc.Player):


### PR DESCRIPTION
The function should always return True or False, never None. The indentation of
the "return True" was wrong, making it inside an if. This patch just moves it
outside, making it a "catch all" return, and then fixing when the function ended
without running a return statement.

This issue broke the plugin as None evaluates as False causing the plugin to
never search for subtitles.
