### PR TITLE
Change in language string

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,26 +2,26 @@
 <settings>
     <!-- General -->
     <category id="general" label="30010">
-	<setting id="debug" type="bool" label="30100" default="false"/>
+        <setting id="debug" type="bool" label="30100" default="false"/>
         <setting id="check_for_specific" type="bool" default="false" label="30101"/>
-        <setting id="selected_language" type="select" enable="eq(-1,true)" visible="eq(-1,true)" label="30102" default="English" values="African|Albanian|Arabic|Armenian|Basque|Bengali|Bosnian|Breton|Bulgarian|Burmese|Catalan|Chinese|Croatian|Czech|Danish|Dutch|English|Esperanto|Estonian|Finnish|French|Galician|Georgian|German|Greek|Hebrew|Hindi|Hungarian|Icelandic|Indonesian|Italian|Japanese|Kazakh|Khmer|Korean|Latvian|Lithuanian|Luxembourgish|Macedonian|Malay|Malayalam|Manipuri|Mongolian|Montenegrin|Norwegian|Occitan|Persian|Polish|Portuguese|Portuguese (Brazil)|Romanian|Russian|Serbian|Sinhalese|Slovak|Slovenian|Spanish|Swahili|Swedish|Syriac|Tagalog|Tamil|Telugu|Thai|Turkish|Ukrainian|Urdu" />
+        <setting id="selected_language" type="select" enable="eq(-1,true)" visible="eq(-1,true)" label="30102" default="English" values="Albanian|Arabic|Belarusian|Bosnian (Latin)|Bulgarian|Catalan|Chinese|Croatian|Czech|Danish|Dutch|English|Estonian|Finnish|French|German|Greek|Hebrew|Hindi|Hungarian|Icelandic|Indonesian|Italian|Japanese|Korean|Latvian|Lithuanian|Macedonian|Norwegian|Polish|Portuguese|Romanian|Russian|SerbianLatin|Slovak|Slovenian|Spanish|Swedish|Thai|Turkish|Ukrainian|Vietnamese|Farsi|Malay" />
     </category>
     
     <!-- Exclusions -->
     <category id="exclusions" label="30020">	
-	<setting id="ExcludeTime" type="number" label="30200" default="15"/>   	
+        <setting id="ExcludeTime" type="number" label="30200" default="15"/>   	
         <setting id="ignore_words" type="text" default="theme" label="30201"/>
         <setting id="ExcludeLiveTV" type="bool" label="30202" default="false"/>
-	<setting id="ExcludeHTTP" type="bool" label="30203" default="false"/>    
-	<setting id="ExcludePathOption" type="bool" label="30204" default="false" />
-	<setting id="ExcludePath" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
-	<setting id="ExcludePathOption2" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
-	<setting id="ExcludePath2" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
-	<setting id="ExcludePathOption3" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
-	<setting id="ExcludePath3" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
-	<setting id="ExcludePathOption4" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
-	<setting id="ExcludePath4" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
-	<setting id="ExcludePathOption5" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
-	<setting id="ExcludePath5" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+        <setting id="ExcludeHTTP" type="bool" label="30203" default="false"/>    
+        <setting id="ExcludePathOption" type="bool" label="30204" default="false" />
+        <setting id="ExcludePath" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+        <setting id="ExcludePathOption2" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+        <setting id="ExcludePath2" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+        <setting id="ExcludePathOption3" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+        <setting id="ExcludePath3" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+        <setting id="ExcludePathOption4" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+        <setting id="ExcludePath4" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
+        <setting id="ExcludePathOption5" type="bool" label="30204" default="false" visible= "eq(-2,true)" enable="eq(-2,true)" />
+        <setting id="ExcludePath5" type="folder" source="video" label="30205" default="" visible= "eq(-1,true)" enable="eq(-1,true)" />
     </category>
 </settings>


### PR DESCRIPTION
Only selected_language that was on strings.xml direct in the option.
Drop of Portuguese (Brazil) option.
There is no ISO for that language, only Portuguese is known.
So many subtitle services download the subtitles with .pt.srt in the end
or without nothing. So brazilian and portuguese subtitles are always
shown as pt. in case of brazilian sometimes arent presented as correct
language.
