### PR TITLE
Delay to make shure subtitles are loaded

### DIFF
--- a/default.py
+++ b/default.py
@@ -113,6 +113,7 @@ class AutoSubsPlayer(xbmc.Player):
         if self.run:
             movieFullPath = xbmc.Player().getPlayingFile()
             Debug("movieFullPath '%s'" % movieFullPath)
+            xbmc.sleep(1000)
             availableLangs = xbmc.Player().getAvailableSubtitleStreams()
             Debug("availableLangs '%s'" % availableLangs)
             totalTime = xbmc.Player().getTotalTime()


### PR DESCRIPTION
I've been testing the addon with some stream services and sometimes it seems that even with services that load subtitles with video, when it passes in the code to check the availableLangs it still didn't got that information.
Putting the 1 sec delays it seems to solve the question.
