### PR TITLE
Fix for addons that load own subtitles

### DIFF
--- a/default.py
+++ b/default.py
@@ -109,7 +109,10 @@ class AutoSubsPlayer(xbmc.Player):
         check_for_specific = (__addon__.getSetting('check_for_specific').lower() == 'true')
         specific_language = (__addon__.getSetting('selected_language'))
         specific_language = xbmc.convertLanguage(specific_language, xbmc.ISO_639_2)
-
+        try:
+            xbmc.sleep(3000)
+            if self.getSubtitles(): self.run = false
+        except: pass
         if self.run:
             movieFullPath = xbmc.Player().getPlayingFile()
             Debug("movieFullPath '%s'" % movieFullPath)


### PR DESCRIPTION
Some addons load their subtitles onPlayBackStarted this delay gives time to subtitles be loaded by addon before autosubs check if subtitles already exist to the video.