### PR TITLE
If subtitle already exists force it on

### DIFF
--- a/default.py
+++ b/default.py
@@ -147,6 +147,7 @@ class AutoSubsPlayer(xbmc.Player):
                     xbmc.executebuiltin('XBMC.ActivateWindow(SubtitleSearch)')
                 else:
                     Debug('Started: Subs found or Excluded')
+                    xbmc.Player().showSubtitles(True)
                     self.run = False
         else:
             Debug('Started: Not a video file, finishing')


### PR DESCRIPTION
Since there is a bug or missing feature on Kodi where Kodi doesn't remember if user have turned subtitles on and saved the setting, I thought this addon could do the same thing.